### PR TITLE
fix: avoid server errors when calling the /bot endpoint

### DIFF
--- a/plugins/sendBotMessage.js
+++ b/plugins/sendBotMessage.js
@@ -32,7 +32,7 @@ export default async function sendBotMessage(
   options,
   { toJid, accountId, content, isMarkdown }
 ) {
-  const token = await getBotToken(accountId)
+  const token = await getBotToken(fastify, options, accountId)
 
   return apiFetch(token, '/im/chat/messages', {
     method: 'POST',


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/nearform/zoom-talking-stick/commit/cca726e43093c67d7f622c9fa6f2080cc6362de2 resulting in calls to `/bot` ending up on server errors.

(not caught by integration tests as this was within a mocked function 😬)