### PR TITLE
fix: missing port env variable from deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,7 +96,6 @@ jobs:
           --source=.
           --set-env-vars='
           NODE_ENV=production,
-          PORT=3000,
           DB_USER=${{ env.SQL_ROOT_USERNAME }},
           DB_PASSWORD=${{ secrets.SQL_ROOT_PASSWORD }},
           DB_HOST=${{ env.SQL_HOST }},

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,6 +96,7 @@ jobs:
           --source=.
           --set-env-vars='
           NODE_ENV=production,
+          PORT=3000,
           DB_USER=${{ env.SQL_ROOT_USERNAME }},
           DB_PASSWORD=${{ secrets.SQL_ROOT_PASSWORD }},
           DB_HOST=${{ env.SQL_HOST }},

--- a/chatbot.js
+++ b/chatbot.js
@@ -5,7 +5,7 @@ const server = buildServer(config)
 
 const start = async () => {
   try {
-    await server.listen(process.env.PORT, '0.0.0.0')
+    await server.listen({ port: process.env.PORT, host: '0.0.0.0' })
   } catch (err) {
     server.log.error(err)
     process.exit(1)


### PR DESCRIPTION
resolves: https://github.com/nearform/zoom-shuffle-bot/issues/233
Trying to explicitate the port environment variable which it seems missing.
It seems GCP listens on port 8080 
`ERROR: (gcloud.beta.run.deploy) The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable. Logs for this revision might contain more information.`
And the application starts on a random port:
`{"hostname":"localhost", "level":30, "msg":"Server listening at http://0.0.0.0:36749", "pid":16, "time":1.662972495749E12}`
 I don't understand what could have been the breaking change since last deployment