### PR TITLE
fix: prevent action from failing when deleting secret

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,7 +89,7 @@ jobs:
             gcloud secrets delete $secret || true
 
             # re-create the secret
-            gcloud secrets create --locations=${{ secrets.GCP_REGION }} --replication-policy=user-managed $secret
+            gcloud secrets create --locations=${{ secrets.GCP_REGION }} --replication-policy=user-managed $secret || true
           done
 
           # update the secrets

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,7 +86,7 @@ jobs:
           for secret in shuffle-db-host shuffle-db-username shuffle-db-password shuffle-db-name shuffle-client-id shuffle-client-secret shuffle-bot-jid shuffle-redirect-url shuffle-verification-token
           do
             # delete the secret
-            gcloud secrets delete $secret
+            gcloud secrets delete $secret || true
 
             # re-create the secret
             gcloud secrets create --locations=${{ secrets.GCP_REGION }} --replication-policy=user-managed $secret

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,10 +86,10 @@ jobs:
           for secret in shuffle-db-host shuffle-db-username shuffle-db-password shuffle-db-name shuffle-client-id shuffle-client-secret shuffle-bot-jid shuffle-redirect-url shuffle-verification-token
           do
             # delete the secret
-            gcloud secrets delete $secret || true
+            gcloud secrets delete --quiet $secret || true
 
             # re-create the secret
-            gcloud secrets create --locations=${{ secrets.GCP_REGION }} --replication-policy=user-managed $secret || true
+            gcloud secrets create --locations=${{ secrets.GCP_REGION }} --replication-policy=user-managed $secret
           done
 
           # update the secrets


### PR DESCRIPTION
We weren't supposed to need doing that, but here it is. (according to https://cloud.google.com/sdk/gcloud/reference/secrets/delete, "If the given secret does not exist, this command will succeed, but the operation will be a no-op.")