### PR TITLE
fix: ignore unknown commands

### DIFF
--- a/routes/bot.js
+++ b/routes/bot.js
@@ -15,7 +15,7 @@ export default async function (fastify) {
           payload: { toJid, userJid, accountId, userId, cmd, userName },
         } = req.body
 
-        if(!ACCEPTED_COMMANDS.includes(cmd)) {
+        if (!ACCEPTED_COMMANDS.includes(cmd)) {
           res.code(200).send()
           return
         }
@@ -71,7 +71,7 @@ export default async function (fastify) {
           }
         } else {
           updatedParticipants = participants
-        } 
+        }
 
         const randomParticipants = sortRandomly(updatedParticipants)
 

--- a/routes/bot.js
+++ b/routes/bot.js
@@ -3,6 +3,8 @@ import { decrypt } from '../helpers/crypto.js'
 import { SUBCOMMANDS } from '../const.js'
 import sortRandomly from '../helpers/sortRandomly.js'
 
+const ACCEPTED_COMMANDS = ['', 'skipme']
+
 export default async function (fastify) {
   fastify.post(
     '/bot',
@@ -12,6 +14,11 @@ export default async function (fastify) {
         const {
           payload: { toJid, userJid, accountId, userId, cmd, userName },
         } = req.body
+
+        if(!ACCEPTED_COMMANDS.includes(cmd)) {
+          res.code(200).send()
+          return
+        }
 
         const sendMessage = (content, isMarkdown) => {
           return fastify.zoom.sendBotMessage({
@@ -64,7 +71,7 @@ export default async function (fastify) {
           }
         } else {
           updatedParticipants = participants
-        }
+        } 
 
         const randomParticipants = sortRandomly(updatedParticipants)
 

--- a/test/integration/bot.test.js
+++ b/test/integration/bot.test.js
@@ -48,6 +48,32 @@ describe('/bot route logic', () => {
     await resetDatabase(server)
   })
 
+  it('ignores an unknown command', async () => {
+    expect(sendBotMessage).not.toHaveBeenCalled()
+
+    const timestamp = 123456789
+    const payload = {
+      payload: {
+        userId: 'non-existing-id',
+        cmd: 'an-unknown-command',
+      },
+    }
+    const response = await server.inject({
+      url: '/bot',
+      method: 'POST',
+      headers: {
+        clientid: process.env.CLIENT_ID,
+        'x-zm-request-timestamp': timestamp,
+        'x-zm-signature': createVerificationSignature(timestamp, payload),
+      },
+      payload,
+    })
+
+    expect(response.statusCode).toBe(200)
+
+    expect(sendBotMessage).toHaveBeenCalledTimes(0)
+  })
+
   it('sends a bot message when user has no active meetings', async () => {
     expect(sendBotMessage).not.toHaveBeenCalled()
 
@@ -55,6 +81,7 @@ describe('/bot route logic', () => {
     const payload = {
       payload: {
         userId: 'non-existing-id',
+        cmd: '',
       },
     }
     const response = await server.inject({
@@ -89,6 +116,7 @@ describe('/bot route logic', () => {
       payload: {
         accountId: 'test_account_id',
         userId: 'test_user_id',
+        cmd: '',
       },
     }
     const response = await server.inject({


### PR DESCRIPTION
Shufflebot was responding to anytext as if the /shuffle command had been issued.

This PR defines an array of accepted commands (blank if /shuffle, otherwise contains the subcommand) and simply responds to the hook request with a 200 if anything else is received in the payload.