### PR TITLE
chore: add timestamp validation & add tests to cover

### DIFF
--- a/plugins/verifyRequest.js
+++ b/plugins/verifyRequest.js
@@ -4,9 +4,17 @@ import { createVerificationSignature } from '../helpers/crypto.js'
 const TIMESTAMP_THRESHOLD = 5 * 60 * 1000 // 5 minutes
 
 export default async function verifyRequest(req) {
-  const timestamp = req.headers['x-zm-request-timestamp']
+  // header received from Zoom is in epoch (seconds) format,
+  // need to convert before comparing
+  const epochStamp = Number(req.headers['x-zm-request-timestamp'])
 
-  if (Date.now() - Number(timestamp) >= TIMESTAMP_THRESHOLD) {
+  if (isNaN(epochStamp)) {
+    throw createError(401)
+  }
+
+  const timestamp = epochStamp * 1000
+
+  if (Date.now() - timestamp >= TIMESTAMP_THRESHOLD) {
     throw createError(401)
   }
 

--- a/plugins/verifyRequest.js
+++ b/plugins/verifyRequest.js
@@ -1,8 +1,15 @@
 import createError from 'http-errors'
 import { createVerificationSignature } from '../helpers/crypto.js'
 
+const TIMESTAMP_THRESHOLD = 5 * 60 * 1000 // 5 minutes
+
 export default async function verifyRequest(req) {
   const timestamp = req.headers['x-zm-request-timestamp']
+
+  if (Date.now() - Number(timestamp) >= TIMESTAMP_THRESHOLD) {
+    throw createError(401)
+  }
+
   const signature = createVerificationSignature(timestamp, req.body)
 
   if (signature !== req.headers['x-zm-signature']) {

--- a/plugins/verifyRequest.js
+++ b/plugins/verifyRequest.js
@@ -18,7 +18,7 @@ export default async function verifyRequest(req) {
     throw createError(401)
   }
 
-  const signature = createVerificationSignature(timestamp, req.body)
+  const signature = createVerificationSignature(epochStamp, req.body)
 
   if (signature !== req.headers['x-zm-signature']) {
     throw createError(401)

--- a/plugins/verifyRequest.test.js
+++ b/plugins/verifyRequest.test.js
@@ -13,7 +13,7 @@ describe('verifyRequest()', () => {
     await expect(async () => {
       await verifyRequest({
         headers: {
-          'x-zm-request-timestamp': Date.now(),
+          'x-zm-request-timestamp': Math.floor(Date.now() / 1000),
           'x-zm-signature': '',
         },
         body: { foo: 'bar' },
@@ -28,7 +28,19 @@ describe('verifyRequest()', () => {
     await expect(async () => {
       await verifyRequest({
         headers: {
-          'x-zm-request-timestamp': stamp.valueOf(),
+          'x-zm-request-timestamp': Math.floor(stamp.valueOf() / 1000),
+          'x-zm-signature': '', // signature not relevant here, timestamp check comes first
+        },
+        body: { foo: 'bar' },
+      })
+    }).rejects.toThrow()
+  })
+
+  it('throws Invalid when timestamp is non-numeric', async () => {
+    await expect(async () => {
+      await verifyRequest({
+        headers: {
+          'x-zm-request-timestamp': 'hang on a minute...',
           'x-zm-signature': '', // signature not relevant here, timestamp check comes first
         },
         body: { foo: 'bar' },
@@ -39,11 +51,12 @@ describe('verifyRequest()', () => {
   it("doesn't throw when signature is valid", async () => {
     const body = { foo: 'bar' }
     const now = Date.now()
+
     const signature = createVerificationSignature(now, body)
     await expect(async () => {
       await verifyRequest({
         headers: {
-          'x-zm-request-timestamp': now,
+          'x-zm-request-timestamp': now / 1000,
           'x-zm-signature': signature,
         },
         body,

--- a/plugins/verifyRequest.test.js
+++ b/plugins/verifyRequest.test.js
@@ -50,13 +50,13 @@ describe('verifyRequest()', () => {
 
   it("doesn't throw when signature is valid", async () => {
     const body = { foo: 'bar' }
-    const now = Date.now()
+    const epoch = Math.floor(Date.now() / 1000)
 
-    const signature = createVerificationSignature(now, body)
+    const signature = createVerificationSignature(epoch, body)
     await expect(async () => {
       await verifyRequest({
         headers: {
-          'x-zm-request-timestamp': now / 1000,
+          'x-zm-request-timestamp': epoch,
           'x-zm-signature': signature,
         },
         body,

--- a/test/integration/bot.test.js
+++ b/test/integration/bot.test.js
@@ -33,7 +33,7 @@ describe('/bot route verification', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -63,7 +63,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -89,7 +89,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -124,7 +124,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,

--- a/test/integration/bot.test.js
+++ b/test/integration/bot.test.js
@@ -24,7 +24,7 @@ describe('/bot route verification', () => {
   })
 
   it('responds with 200 when verified', async () => {
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       payload: {},
     }
@@ -51,7 +51,7 @@ describe('/bot route logic', () => {
   it('ignores an unknown command', async () => {
     expect(sendBotMessage).not.toHaveBeenCalled()
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       payload: {
         userId: 'non-existing-id',
@@ -77,7 +77,7 @@ describe('/bot route logic', () => {
   it('sends a bot message when user has no active meetings', async () => {
     expect(sendBotMessage).not.toHaveBeenCalled()
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       payload: {
         userId: 'non-existing-id',
@@ -111,7 +111,7 @@ describe('/bot route logic', () => {
 
     apiFetch.mockResolvedValueOnce({ topic: 'Test meeting topic' })
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       payload: {
         accountId: 'test_account_id',

--- a/test/integration/bot.test.js
+++ b/test/integration/bot.test.js
@@ -16,7 +16,13 @@ expect.extend({
   },
 })
 
+let timestamp = 0
+
 describe('/bot route verification', () => {
+  beforeEach(() => {
+    timestamp = Math.floor(Date.now() / 1000)
+  })
+
   it('responds with 401 when not verified', async () => {
     const response = await server.inject({ url: '/bot', method: 'POST' })
 
@@ -24,7 +30,6 @@ describe('/bot route verification', () => {
   })
 
   it('responds with 200 when verified', async () => {
-    const timestamp = Date.now()
     const payload = {
       payload: {},
     }
@@ -33,7 +38,7 @@ describe('/bot route verification', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -46,12 +51,12 @@ describe('/bot route verification', () => {
 describe('/bot route logic', () => {
   beforeEach(async () => {
     await resetDatabase(server)
+    timestamp = Math.floor(Date.now() / 1000)
   })
 
   it('ignores an unknown command', async () => {
     expect(sendBotMessage).not.toHaveBeenCalled()
 
-    const timestamp = Date.now()
     const payload = {
       payload: {
         userId: 'non-existing-id',
@@ -63,7 +68,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -77,7 +82,6 @@ describe('/bot route logic', () => {
   it('sends a bot message when user has no active meetings', async () => {
     expect(sendBotMessage).not.toHaveBeenCalled()
 
-    const timestamp = Date.now()
     const payload = {
       payload: {
         userId: 'non-existing-id',
@@ -89,7 +93,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -111,7 +115,6 @@ describe('/bot route logic', () => {
 
     apiFetch.mockResolvedValueOnce({ topic: 'Test meeting topic' })
 
-    const timestamp = Date.now()
     const payload = {
       payload: {
         accountId: 'test_account_id',
@@ -124,7 +127,7 @@ describe('/bot route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,

--- a/test/integration/hook.test.js
+++ b/test/integration/hook.test.js
@@ -9,7 +9,13 @@ import { createVerificationSignature } from '../../helpers/crypto.js'
 
 const server = getTestServer()
 
+let timestamp = 0
+
 describe('/hook route verification', () => {
+  beforeEach(() => {
+    timestamp = Math.floor(Date.now() / 1000)
+  })
+
   it('responds with 401 when not verified', async () => {
     const response = await server.inject({ url: '/hook', method: 'POST' })
 
@@ -17,7 +23,6 @@ describe('/hook route verification', () => {
   })
 
   it('responds with 200 when verified', async () => {
-    const timestamp = Date.now()
     const payload = {
       payload: {
         object: {},
@@ -28,7 +33,7 @@ describe('/hook route verification', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -41,6 +46,7 @@ describe('/hook route verification', () => {
 describe('/hook route logic', () => {
   beforeEach(async () => {
     await resetDatabase(server)
+    timestamp = Math.floor(Date.now() / 1000)
   })
 
   it('adds a meeting participant when a meeting is joined (and the meeting exists)', async () => {
@@ -50,7 +56,6 @@ describe('/hook route logic', () => {
 
     expect(meeting.data().users).not.toContain('new-user-id')
 
-    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -69,7 +74,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -93,7 +98,6 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(false)
 
-    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -112,7 +116,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -136,7 +140,6 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(false)
 
-    const timestamp = Date.now()
     let payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -154,7 +157,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -178,7 +181,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -205,7 +208,6 @@ describe('/hook route logic', () => {
       '680eda40e80d89c8b3d7fdfe074042e9'
     )
 
-    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_LEFT,
       payload: {
@@ -224,7 +226,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -248,7 +250,6 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(true)
 
-    const timestamp = Date.now()
     const payload = {
       event: EVENT_MEETING_ENDED,
       payload: {
@@ -263,7 +264,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp / 1000,
+        'x-zm-request-timestamp': timestamp,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,

--- a/test/integration/hook.test.js
+++ b/test/integration/hook.test.js
@@ -28,7 +28,7 @@ describe('/hook route verification', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -69,7 +69,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -112,7 +112,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -154,7 +154,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -178,7 +178,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -224,7 +224,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,
@@ -263,7 +263,7 @@ describe('/hook route logic', () => {
       method: 'POST',
       headers: {
         clientid: process.env.CLIENT_ID,
-        'x-zm-request-timestamp': timestamp,
+        'x-zm-request-timestamp': timestamp / 1000,
         'x-zm-signature': createVerificationSignature(timestamp, payload),
       },
       payload,

--- a/test/integration/hook.test.js
+++ b/test/integration/hook.test.js
@@ -17,7 +17,7 @@ describe('/hook route verification', () => {
   })
 
   it('responds with 200 when verified', async () => {
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       payload: {
         object: {},
@@ -50,7 +50,7 @@ describe('/hook route logic', () => {
 
     expect(meeting.data().users).not.toContain('new-user-id')
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -93,7 +93,7 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(false)
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -136,7 +136,7 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(false)
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     let payload = {
       event: EVENT_PARTICIPANT_JOINED,
       payload: {
@@ -205,7 +205,7 @@ describe('/hook route logic', () => {
       '680eda40e80d89c8b3d7fdfe074042e9'
     )
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       event: EVENT_PARTICIPANT_LEFT,
       payload: {
@@ -248,7 +248,7 @@ describe('/hook route logic', () => {
 
     expect(meeting.exists).toBe(true)
 
-    const timestamp = 123456789
+    const timestamp = Date.now()
     const payload = {
       event: EVENT_MEETING_ENDED,
       payload: {


### PR DESCRIPTION
Fixes #480 

### Manual testing carried out
- [x] Request with no timestamp rejected
- [x] Request with timestamp >= 5 minutes in the past rejected
- [x] Request with bad signature still rejected
- [x] Request with good signature and timestamp < 5 minutes in the past allowed