### PR TITLE
build: drop node-fetch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "fastify-plugin": "^6.0.0",
         "fluent-json-schema": "^6.0.0",
         "http-errors": "^2.0.1",
-        "node-fetch": "^3.3.2",
         "pg": "^8.22.0",
         "pino-pretty": "^13.1.3"
       },
@@ -8902,31 +8901,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -24156,30 +24130,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "fastify-plugin": "^6.0.0",
     "fluent-json-schema": "^6.0.0",
     "http-errors": "^2.0.1",
-    "node-fetch": "^3.3.2",
     "pg": "^8.22.0",
     "pino-pretty": "^13.1.3"
   },

--- a/plugins/apiFetch.js
+++ b/plugins/apiFetch.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import createError from 'http-errors'
 
 import { ZOOM_API_BASE_URL } from '../const.js'

--- a/plugins/oauth.js
+++ b/plugins/oauth.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 import createError from 'http-errors'
 import { ZOOM_AUTH_BASE_URL } from '../const.js'
 


### PR DESCRIPTION
Aligns #1015 with master and keeps only the node-fetch removal.

Node.js 18+ provides a native `fetch` implementation, so the `node-fetch` package is no longer needed.

Changes:
- Remove `node-fetch` from `package.json` dependencies
- Drop `import fetch from 'node-fetch'` in `plugins/apiFetch.js` and `plugins/oauth.js` (native `fetch` is now used)
- Update `package-lock.json` accordingly